### PR TITLE
Fix: x86 build failure due to missing #include <linux/fs.h> in t241-clink-ioctl.c

### DIFF
--- a/t241-clink-ioctl.c
+++ b/t241-clink-ioctl.c
@@ -43,6 +43,7 @@
 #include <linux/version.h>
 #include <linux/delay.h>
 #include <linux/uaccess.h>
+#include <linux/fs.h>
 #include "t241-clink.h"
 #include "t241-clink-hw.h"
 #include "t241-clink-ioctl.h"


### PR DESCRIPTION
This error occurs only when building in the x86-64 environment; aarch64 builds are fine.

[build.log](https://github.com/user-attachments/files/17711015/build.log)